### PR TITLE
Remove Nightly Dependency and Add Integration Tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-analyze"
-version = "0.1.1"
+version = "0.1.0"
 edition = "2021"
 description = "A simple command-line program for investigating strings of UTF-8 text"
 repository = "https://github.com/Esper89/unicode-analyze"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-analyze"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A simple command-line program for investigating strings of UTF-8 text"
 repository = "https://github.com/Esper89/unicode-analyze"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ## Installation
 
 To install `unicode-analyze`, run `cargo install --git https://github.com/Esper89/unicode-analyze`.
-This crate requires a nightly installation of the Rust toolchain.
 
 ## Examples
 
@@ -114,7 +113,7 @@ U+FFFF ∅ NOT A CHARACTER
 
 ## License
 
-Copyright © 2023–2024 Esper Thomson
+Copyright © 2023–2025 Esper Thomson
 
 This program is free software: you can redistribute it and/or modify it under the terms of version 3
 of the GNU Affero General Public License, as published by the Free Software Foundation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,14 @@
-#![feature(utf8_chunks)]
-
-use std::{cmp, ffi::OsStr, fmt::{self, Display}, hash, ops, str::Utf8Chunks};
+use std::{cmp, ffi::OsStr, fmt::{self, Display}, hash, ops};
 use either::Either;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use unicode_segmentation::UnicodeSegmentation;
-use unicode::{CharName, Character, Diacritic, Direction};
+use unicode::{Character, CharName, Diacritic, Direction};
 
 mod unicode;
 
 // TODO: Reduce the size of each `Codepoint` or switch to some kind of iteration.
 
 // TODO: Add doc comments.
-
-// TODO: Replace the `utf8_chunks` unstable feature with something else.
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Default)]
 pub struct Text(Vec<Grapheme>);
@@ -48,7 +44,7 @@ impl Text {
             Invalid(&'a [u8]),
         }
 
-        Text(Utf8Chunks::new(text)
+        Text(text.utf8_chunks()
             .flat_map(|chunk| {
                 let (valid, invalid) = (chunk.valid(), chunk.invalid());
                 let mut items = SmallVec::<[Utf8; 2]>::new();
@@ -178,7 +174,7 @@ fn display_with(f: impl Fn(&mut fmt::Formatter) -> fmt::Result) -> impl Display 
 
 impl Display for Text {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut graphemes = self.graphemes().filter(|g| g.len() > 0);
+        let mut graphemes = self.graphemes().filter(|g| !g.is_empty());
         f.write_str("[")?;
 
         if let Some(first) = graphemes.next() { first.fmt(f)?; }

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -9,7 +9,7 @@ struct TestCase {
 impl TestCase {
     fn run(self) {
         assert_eq!(self.text.to_string(), self.string_rep);
-        let codepoints: Vec<_> = self.text.codepoints().collect();
+        let codepoints = self.text.codepoints().collect::<Vec<_>>();
         assert_eq!(self.out.len(), codepoints.len());
 
         for ((value, character, name), codepoint) in self.out.iter().cloned().zip(codepoints) {
@@ -22,7 +22,6 @@ impl TestCase {
 
 #[test]
 fn hello_world() {
-    // 'Hello, World!'
     TestCase {
         text: Text::parse_str("Hello, World!"),
         string_rep: "['H', 'e', 'l', 'l', 'o', ',', ' ', 'W', 'o', 'r', 'l', 'd', '!']",
@@ -47,7 +46,6 @@ fn hello_world() {
 
 #[test]
 fn control_codes() {
-    // $'\v\t\r\n'
     TestCase {
         text: Text::parse_str("\u{000B}\t\r\n"),
         string_rep: "[VT, HT, [CR + LF]]",
@@ -63,7 +61,6 @@ fn control_codes() {
 
 #[test]
 fn emojis() {
-    // '👩‍👩‍👧‍👦 😵‍💫'
     TestCase {
         text: Text::parse_str("👩‍👩‍👧‍👦 😵‍💫"),
         string_rep: "[['👩' + ZWJ + '👩' + ZWJ + '👧' + ZWJ + '👦'], ' ', ['😵' + ZWJ + '💫']]",
@@ -86,7 +83,6 @@ fn emojis() {
 
 #[test]
 fn combining_characters() {
-    // m͌͊e̵͂o͐͝w͐̾
     TestCase {
         text: Text::parse_str("m͌͊e̵͂o͐͝w͐̾"),
         string_rep: "[['m' + '◌͌' + '◌͊'], ['e' + '◌̵' + '◌͂'], ['o' + '◌͐' + '◌͝◌'], ['w' + '◌͐' \
@@ -111,11 +107,10 @@ fn combining_characters() {
 
 #[test]
 fn rtl() {
-    // اَلْعَرَبِيَّةُ
     TestCase {
         text: Text::parse_str("اَلْعَرَبِيَّةُ"),
-        string_rep: "[['‎ا‎' + '◌َ'], ['‎ل‎' + '◌ْ'], ['‎ع‎' + '◌َ'], ['‎ر‎' + '◌َ'], ['‎ب‎' + '◌ِ'\
-                     ], ['‎ي‎' + '◌َ' + '◌ّ'], ['‎ة‎' + '◌ُ']]",
+        string_rep: "[['‎ا‎' + '◌َ'], ['‎ل‎' + '◌ْ'], ['‎ع‎' + '◌َ'], ['‎ر‎' + '◌َ'], ['‎ب‎' + '◌ِ'], ['‎ي‎' + '◌َ' \
+                    + '◌ّ'], ['‎ة‎' + '◌ُ']]",
         out: &[
             ("U+0627", "'‎ا‎'", "ARABIC LETTER ALEF"),
             ("U+064E", "'◌َ'", "ARABIC FATHA"),
@@ -139,11 +134,8 @@ fn rtl() {
 
 #[test]
 fn invalid() {
-    // $'\xF2\x80\x80\x80\xF4\x8F\xBF\xBD\xEF\xBF\xBF\xFF'
     TestCase {
-        text: Text::parse_bytes(
-            &[0xF2, 0x80, 0x80, 0x80, 0xF4, 0x8F, 0xBF, 0xBD, 0xEF, 0xBF, 0xBF, 0xFF]
-        ),
+        text: Text::parse_bytes(b"\xF2\x80\x80\x80\xF4\x8F\xBF\xBD\xEF\xBF\xBF\xFF"),
         string_rep: "[U+080000, U+10FFFD, U+FFFF, 0xFF]",
         out: &[
             ("U+080000", "?", "UNKNOWN CHARACTER"),

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -131,16 +131,9 @@ fn rtl() {
 
 #[test]
 fn invalid() {
-    use std::ffi::OsStr;
-
     // $'\xF2\x80\x80\x80\xF4\x8F\xBF\xBD\xEF\xBF\xBF\xFF'
     ValidationData {
-        text: Text::parse_os_str(
-            // SAFETY: these are just the encoded bytes, e.g. 0xF2 == 242
-            unsafe { OsStr::from_encoded_bytes_unchecked(
-                &[242, 128, 128, 128, 244, 143, 191, 189, 239, 191, 191, 255]
-            ) }
-        ),
+        text: Text::parse_bytes(&[242, 128, 128, 128, 244, 143, 191, 189, 239, 191, 191, 255]),
         string_rep: "[U+080000, U+10FFFD, U+FFFF, 0xFF]",
         out: &[
             ("U+080000", "?", "UNKNOWN CHARACTER"),

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -1,0 +1,152 @@
+use unicode_analyze::Text;
+
+struct ValidationData {
+    text: Text,
+    string_rep: &'static str,
+    out: &'static [(&'static str, &'static str, &'static str)],
+}
+
+impl ValidationData {
+    fn verify_output(self) {
+        assert_eq!(self.text.to_string(), self.string_rep);
+        let codepoints: Vec<_> = self.text.codepoints().collect();
+        assert_eq!(self.out.len(), codepoints.len());
+        for ((value, character, name), codepoint) in self.out.iter().cloned().zip(codepoints) {
+            assert_eq!(value, codepoint.display_value().to_string());
+            assert_eq!(character, codepoint.display_character().to_string());
+            assert_eq!(name, codepoint.display_name().to_string());
+        }
+    }
+}
+
+#[test]
+fn hello_world() {
+    // 'Hello, World!'
+    ValidationData {
+        text: Text::parse_str("Hello, World!"),
+        string_rep: "['H', 'e', 'l', 'l', 'o', ',', ' ', 'W', 'o', 'r', 'l', 'd', '!']",
+        out: &[
+            ("U+0048", "'H'", "LATIN CAPITAL LETTER H"),
+            ("U+0065", "'e'", "LATIN SMALL LETTER E"),
+            ("U+006C", "'l'", "LATIN SMALL LETTER L"),
+            ("U+006C", "'l'", "LATIN SMALL LETTER L"),
+            ("U+006F", "'o'", "LATIN SMALL LETTER O"),
+            ("U+002C", "','", "COMMA"),
+            ("U+0020", "' '", "SPACE"),
+            ("U+0057", "'W'", "LATIN CAPITAL LETTER W"),
+            ("U+006F", "'o'", "LATIN SMALL LETTER O"),
+            ("U+0072", "'r'", "LATIN SMALL LETTER R"),
+            ("U+006C", "'l'", "LATIN SMALL LETTER L"),
+            ("U+0064", "'d'", "LATIN SMALL LETTER D"),
+            ("U+0021", "'!'", "EXCLAMATION MARK"),
+        ],
+    }.verify_output()
+}
+
+#[test]
+fn control_codes() {
+    // $'\v\t\r\n'
+    ValidationData {
+        text: Text::parse_str("\u{000B}\t\r\n"),
+        string_rep: "[VT, HT, [CR + LF]]",
+        out: &[
+            ("U+000B", "VT", "LINE TABULATION"),
+            ("U+0009", "HT", "CHARACTER TABULATION"),
+            ("U+000D", "CR", "CARRIAGE RETURN"),
+            ("U+000A", "LF", "LINE FEED"),
+        ],
+    }.verify_output()
+}
+
+#[test]
+fn emojis() {
+    // '👩‍👩‍👧‍👦 😵‍💫'
+    ValidationData {
+        text: Text::parse_str("👩‍👩‍👧‍👦 😵‍💫"),
+        string_rep: "[['👩' + ZWJ + '👩' + ZWJ + '👧' + ZWJ + '👦'], ' ', ['😵' + ZWJ + '💫']]",
+        out: &[
+            ("U+01F469", "'👩'", "WOMAN"),
+            ("U+200D", "ZWJ", "ZERO WIDTH JOINER"),
+            ("U+01F469", "'👩'", "WOMAN"),
+            ("U+200D", "ZWJ", "ZERO WIDTH JOINER"),
+            ("U+01F467", "'👧'", "GIRL"),
+            ("U+200D", "ZWJ", "ZERO WIDTH JOINER"),
+            ("U+01F466", "'👦'", "BOY"),
+            ("U+0020", "' '", "SPACE"),
+            ("U+01F635", "'😵'", "DIZZY FACE"),
+            ("U+200D", "ZWJ", "ZERO WIDTH JOINER"),
+            ("U+01F4AB", "'💫'", "DIZZY SYMBOL"),
+        ],
+    }.verify_output()
+}
+
+#[test]
+fn combining_characters() {
+    // m͌͊e̵͂o͐͝w͐̾
+    ValidationData {
+        text: Text::parse_str("m͌͊e̵͂o͐͝w͐̾"),
+        string_rep: "[['m' + '◌͌' + '◌͊'], ['e' + '◌̵' + '◌͂'], ['o' + '◌͐' + '◌͝◌'], ['w' + '◌͐' + '◌̾']]",
+        out: &[
+            ("U+006D", "'m'", "LATIN SMALL LETTER M"),
+            ("U+034C", "'◌͌'", "COMBINING ALMOST EQUAL TO ABOVE"),
+            ("U+034A", "'◌͊'", "COMBINING NOT TILDE ABOVE"),
+            ("U+0065", "'e'", "LATIN SMALL LETTER E"),
+            ("U+0335", "'◌̵'", "COMBINING SHORT STROKE OVERLAY"),
+            ("U+0342", "'◌͂'", "COMBINING GREEK PERISPOMENI"),
+            ("U+006F", "'o'", "LATIN SMALL LETTER O"),
+            ("U+0350", "'◌͐'", "COMBINING RIGHT ARROWHEAD ABOVE"),
+            ("U+035D", "'◌͝◌'", "COMBINING DOUBLE BREVE"),
+            ("U+0077", "'w'", "LATIN SMALL LETTER W"),
+            ("U+0350", "'◌͐'", "COMBINING RIGHT ARROWHEAD ABOVE"),
+            ("U+033E", "'◌̾'", "COMBINING VERTICAL TILDE"),
+        ],
+    }.verify_output()
+}
+
+#[test]
+fn rtl() {
+    // اَلْعَرَبِيَّةُ
+    ValidationData {
+        text: Text::parse_str("اَلْعَرَبِيَّةُ"),
+        string_rep: "[['‎ا‎' + '◌َ'], ['‎ل‎' + '◌ْ'], ['‎ع‎' + '◌َ'], ['‎ر‎' + '◌َ'], ['‎ب‎' + '◌ِ'], ['‎ي‎' + '◌َ' + '◌ّ'], ['‎ة‎' + '◌ُ']]",
+        out: &[
+            ("U+0627", "'‎ا‎'", "ARABIC LETTER ALEF"),
+            ("U+064E", "'◌َ'", "ARABIC FATHA"),
+            ("U+0644", "'‎ل‎'", "ARABIC LETTER LAM"),
+            ("U+0652", "'◌ْ'", "ARABIC SUKUN"),
+            ("U+0639", "'‎ع‎'", "ARABIC LETTER AIN"),
+            ("U+064E", "'◌َ'", "ARABIC FATHA"),
+            ("U+0631", "'‎ر‎'", "ARABIC LETTER REH"),
+            ("U+064E", "'◌َ'", "ARABIC FATHA"),
+            ("U+0628", "'‎ب‎'", "ARABIC LETTER BEH"),
+            ("U+0650", "'◌ِ'", "ARABIC KASRA"),
+            ("U+064A", "'‎ي‎'", "ARABIC LETTER YEH"),
+            ("U+064E", "'◌َ'", "ARABIC FATHA"),
+            ("U+0651", "'◌ّ'", "ARABIC SHADDA"),
+            ("U+0629", "'‎ة‎'", "ARABIC LETTER TEH MARBUTA"),
+            ("U+064F", "'◌ُ'", "ARABIC DAMMA"),
+        ],
+    }.verify_output()
+}
+
+#[test]
+fn invalid() {
+    use std::ffi::OsStr;
+
+    // $'\xF2\x80\x80\x80\xF4\x8F\xBF\xBD\xEF\xBF\xBF\xFF'
+    ValidationData {
+        text: Text::parse_os_str(
+            // SAFETY: these are just the encoded bytes, e.g. 0xF2 == 242
+            unsafe { OsStr::from_encoded_bytes_unchecked(
+                &[242, 128, 128, 128, 244, 143, 191, 189, 239, 191, 191, 255]
+            ) }
+        ),
+        string_rep: "[U+080000, U+10FFFD, U+FFFF, 0xFF]",
+        out: &[
+            ("U+080000", "?", "UNKNOWN CHARACTER"),
+            ("U+10FFFD", "▨", "RESERVED FOR PRIVATE USE"),
+            ("U+FFFF", "∅", "NOT A CHARACTER"),
+            ("0xFF", "�", "INVALID UTF-8"),
+        ],
+    }.verify_output()
+}

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -1,16 +1,17 @@
 use unicode_analyze::Text;
 
-struct ValidationData {
+struct TestCase {
     text: Text,
     string_rep: &'static str,
     out: &'static [(&'static str, &'static str, &'static str)],
 }
 
-impl ValidationData {
-    fn verify_output(self) {
+impl TestCase {
+    fn run(self) {
         assert_eq!(self.text.to_string(), self.string_rep);
         let codepoints: Vec<_> = self.text.codepoints().collect();
         assert_eq!(self.out.len(), codepoints.len());
+
         for ((value, character, name), codepoint) in self.out.iter().cloned().zip(codepoints) {
             assert_eq!(value, codepoint.display_value().to_string());
             assert_eq!(character, codepoint.display_character().to_string());
@@ -22,7 +23,7 @@ impl ValidationData {
 #[test]
 fn hello_world() {
     // 'Hello, World!'
-    ValidationData {
+    TestCase {
         text: Text::parse_str("Hello, World!"),
         string_rep: "['H', 'e', 'l', 'l', 'o', ',', ' ', 'W', 'o', 'r', 'l', 'd', '!']",
         out: &[
@@ -40,13 +41,14 @@ fn hello_world() {
             ("U+0064", "'d'", "LATIN SMALL LETTER D"),
             ("U+0021", "'!'", "EXCLAMATION MARK"),
         ],
-    }.verify_output()
+    }
+    .run()
 }
 
 #[test]
 fn control_codes() {
     // $'\v\t\r\n'
-    ValidationData {
+    TestCase {
         text: Text::parse_str("\u{000B}\t\r\n"),
         string_rep: "[VT, HT, [CR + LF]]",
         out: &[
@@ -55,13 +57,14 @@ fn control_codes() {
             ("U+000D", "CR", "CARRIAGE RETURN"),
             ("U+000A", "LF", "LINE FEED"),
         ],
-    }.verify_output()
+    }
+    .run()
 }
 
 #[test]
 fn emojis() {
     // '👩‍👩‍👧‍👦 😵‍💫'
-    ValidationData {
+    TestCase {
         text: Text::parse_str("👩‍👩‍👧‍👦 😵‍💫"),
         string_rep: "[['👩' + ZWJ + '👩' + ZWJ + '👧' + ZWJ + '👦'], ' ', ['😵' + ZWJ + '💫']]",
         out: &[
@@ -77,15 +80,17 @@ fn emojis() {
             ("U+200D", "ZWJ", "ZERO WIDTH JOINER"),
             ("U+01F4AB", "'💫'", "DIZZY SYMBOL"),
         ],
-    }.verify_output()
+    }
+    .run()
 }
 
 #[test]
 fn combining_characters() {
     // m͌͊e̵͂o͐͝w͐̾
-    ValidationData {
+    TestCase {
         text: Text::parse_str("m͌͊e̵͂o͐͝w͐̾"),
-        string_rep: "[['m' + '◌͌' + '◌͊'], ['e' + '◌̵' + '◌͂'], ['o' + '◌͐' + '◌͝◌'], ['w' + '◌͐' + '◌̾']]",
+        string_rep: "[['m' + '◌͌' + '◌͊'], ['e' + '◌̵' + '◌͂'], ['o' + '◌͐' + '◌͝◌'], ['w' + '◌͐' \
+                     + '◌̾']]",
         out: &[
             ("U+006D", "'m'", "LATIN SMALL LETTER M"),
             ("U+034C", "'◌͌'", "COMBINING ALMOST EQUAL TO ABOVE"),
@@ -100,15 +105,17 @@ fn combining_characters() {
             ("U+0350", "'◌͐'", "COMBINING RIGHT ARROWHEAD ABOVE"),
             ("U+033E", "'◌̾'", "COMBINING VERTICAL TILDE"),
         ],
-    }.verify_output()
+    }
+    .run()
 }
 
 #[test]
 fn rtl() {
     // اَلْعَرَبِيَّةُ
-    ValidationData {
+    TestCase {
         text: Text::parse_str("اَلْعَرَبِيَّةُ"),
-        string_rep: "[['‎ا‎' + '◌َ'], ['‎ل‎' + '◌ْ'], ['‎ع‎' + '◌َ'], ['‎ر‎' + '◌َ'], ['‎ب‎' + '◌ِ'], ['‎ي‎' + '◌َ' + '◌ّ'], ['‎ة‎' + '◌ُ']]",
+        string_rep: "[['‎ا‎' + '◌َ'], ['‎ل‎' + '◌ْ'], ['‎ع‎' + '◌َ'], ['‎ر‎' + '◌َ'], ['‎ب‎' + '◌ِ'\
+                     ], ['‎ي‎' + '◌َ' + '◌ّ'], ['‎ة‎' + '◌ُ']]",
         out: &[
             ("U+0627", "'‎ا‎'", "ARABIC LETTER ALEF"),
             ("U+064E", "'◌َ'", "ARABIC FATHA"),
@@ -126,13 +133,14 @@ fn rtl() {
             ("U+0629", "'‎ة‎'", "ARABIC LETTER TEH MARBUTA"),
             ("U+064F", "'◌ُ'", "ARABIC DAMMA"),
         ],
-    }.verify_output()
+    }
+    .run()
 }
 
 #[test]
 fn invalid() {
     // $'\xF2\x80\x80\x80\xF4\x8F\xBF\xBD\xEF\xBF\xBF\xFF'
-    ValidationData {
+    TestCase {
         text: Text::parse_bytes(&[242, 128, 128, 128, 244, 143, 191, 189, 239, 191, 191, 255]),
         string_rep: "[U+080000, U+10FFFD, U+FFFF, 0xFF]",
         out: &[
@@ -141,5 +149,6 @@ fn invalid() {
             ("U+FFFF", "∅", "NOT A CHARACTER"),
             ("0xFF", "�", "INVALID UTF-8"),
         ],
-    }.verify_output()
+    }
+    .run()
 }

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -141,7 +141,9 @@ fn rtl() {
 fn invalid() {
     // $'\xF2\x80\x80\x80\xF4\x8F\xBF\xBD\xEF\xBF\xBF\xFF'
     TestCase {
-        text: Text::parse_bytes(&[242, 128, 128, 128, 244, 143, 191, 189, 239, 191, 191, 255]),
+        text: Text::parse_bytes(
+            &[0xF2, 0x80, 0x80, 0x80, 0xF4, 0x8F, 0xBF, 0xBD, 0xEF, 0xBF, 0xBF, 0xFF]
+        ),
         string_rep: "[U+080000, U+10FFFD, U+FFFF, 0xFF]",
         out: &[
             ("U+080000", "?", "UNKNOWN CHARACTER"),


### PR DESCRIPTION
As [`utf8_chunks` has been stabilized](https://github.com/rust-lang/rust/issues/99543), I have removed the need for any nightly-only features, and updated the code to use the stabilized API.

I have also added unit tests, following the examples in `README.md`, to make sure the code indeed behaves as it should. Note for the last test, involving invalid UTF-8, I needed to use a small `unsafe` block, calling `OsStr::from_encoded_bytes_unchecked`, since Rust does not accept strings such as `"\xFF"`.